### PR TITLE
Fixed paths to make it possible to use MultiSafePay in Hyvä Checkout …

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,23 @@ Add our package to the PaymentMethodsRepo section in the reactapp package.json:
 },
 ```
 
+If you are using [**Hyvä Checkout Example Template**](https://github.com/hyva-themes/magento2-checkout-example), then you should use below configuration instead of above.
+
+File: `src/reactapp/package.json`
+```
+"config": {
+    "paymentMethodsRepo": {
+        "multisafepay": "git@github.com:multisafepay/magento2-hyva-checkout-multisafepay.git -b hyva-checkout-example-template"
+    }
+},
+   ``` 
+
 Install the MultiSafepay package:
 ```
 npm install
 ```
 
-After that, add the MultiSafepay renderer to reactapp/src/PaymentMethods/paymentConfig.json:
+After that, add the MultiSafepay renderer to reactapp/src/paymentMethods/paymentConfig.json:
 
 ```
 {"availablePaymentMethods":[

--- a/src/components/PaymentBaseComponent/PaymentBaseComponent.jsx
+++ b/src/components/PaymentBaseComponent/PaymentBaseComponent.jsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useContext } from 'react';
 import { func, shape } from 'prop-types';
-import RadioInput from '../../../../../components/common/Form/RadioInput';
+import RadioInput from '@hyva/react-checkout/components/common/Form/RadioInput';
+import CheckoutFormContext from '@hyva/react-checkout/context/Form/CheckoutFormContext';
 import { paymentMethodShape } from '../../utility';
-import CheckoutFormContext from '../../../../../context/Form/CheckoutFormContext';
 import usePerformPlaceOrder from '../../hooks/usePerformPlaceOrder';
 
 function PaymentBaseComponent({ method, selected, actions }) {

--- a/src/hooks/useMultiSafepayAppContext.js
+++ b/src/hooks/useMultiSafepayAppContext.js
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 
-import AppContext from '../../../../context/App/AppContext';
+import AppContext from '@hyva/react-checkout/context/App/AppContext';
 
 export default function useMultiSafepayAppContext() {
   const [

--- a/src/hooks/useMultiSafepayCartContext.js
+++ b/src/hooks/useMultiSafepayCartContext.js
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import _get from 'lodash.get';
 
-import CartContext from '../../../../context/Cart/CartContext';
+import CartContext from '@hyva/react-checkout/context/Cart/CartContext';
 
 export default function useMultiSafepayCartContext() {
   const [cartData, { setRestPaymentMethod, setOrderInfo }] =

--- a/src/hooks/usePerformPlaceOrder.js
+++ b/src/hooks/usePerformPlaceOrder.js
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 import _get from 'lodash.get';
 import _set from 'lodash.set';
-import { __ } from '../../../../i18n';
+import { __ } from '@hyva/react-checkout/i18n';
+import { LOGIN_FORM } from '@hyva/react-checkout/config';
 import { performRedirect } from '../utility';
-import { LOGIN_FORM } from '../../../../config';
 import useMultiSafepayAppContext from './useMultiSafepayAppContext';
 import useMultiSafepayCartContext from './useMultiSafepayCartContext';
 

--- a/src/utility/index.js
+++ b/src/utility/index.js
@@ -1,6 +1,6 @@
 import { shape, string } from 'prop-types';
 import _get from 'lodash.get';
-import { config } from '../../../../config';
+import { config } from '@hyva/react-checkout/config';
 
 export const paymentMethodShape = shape({ title: string, code: string });
 


### PR DESCRIPTION
I was trying to implement the MultiSafePay module with the use of [Hyvä Checkout Example Template](https://github.com/hyva-themes/magento2-checkout-example). I came across a couple of errors. Many paths where pointing to nonexistent files. 

For example:
```
Module not found: Error: Can't resolve '../../../../../context/Form/CheckoutFormContext' in '/var/www/application/app/code/Hyva/CheckoutExample/reactapp/src/paymentMethods/multisafepay/src/components/PaymentBaseComponent'
```

I looked into the fixed made for the Hyva_PayOne module, and when porting them to the MultiSafePay module i could build the app and it works now in my Hyva React checkout.

How to test:
Follow the installation instructions for the Hyva Checkout Example Template: https://github.com/hyva-themes/magento2-checkout-example

Use this branch for the paymentMethodsRepo and try to build the app. 

There should not be any errors. 

